### PR TITLE
Add class reference support with godot-cpp#1374.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -7,6 +7,13 @@ env = SConscript("godot-cpp/SConstruct")
 env.Append(CPPPATH=["src/"])
 sources = Glob("src/*.cpp")
 
+if env["target"] in ["editor", "template_debug"]:
+    try:
+        doc_data = env.GodotCPPDocData("src/gen/doc_data.gen.cpp", source=Glob("doc_classes/*.xml"))
+        sources.append(doc_data)
+    except AttributeError:
+        print("Not including class reference as we're targeting a pre-4.3 baseline.")
+
 if env["platform"] == "macos":
     platlibname = "{}.{}.{}".format(libname, env["platform"], env["target"])
     library = env.SharedLibrary(

--- a/demo/project.godot
+++ b/demo/project.godot
@@ -12,5 +12,5 @@ config_version=5
 
 config/name="GDExtension Threen Demo"
 run/main_scene="res://node_2d.tscn"
-config/features=PackedStringArray("4.1")
+config/features=PackedStringArray("4.3")
 config/icon="res://icon.png"

--- a/doc_classes/Threen.xml
+++ b/doc_classes/Threen.xml
@@ -1,0 +1,344 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="Threen" inherits="Node" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		Smoothly animates a node's properties over time. Forward-port of Godot 3's Tween to Godot 4.
+	</brief_description>
+	<description>
+		Threens are useful for animations requiring a numerical property to be interpolated over a range of values. The name [i]tween[/i] comes from [i]in-betweening[/i], an animation technique where you specify [i]keyframes[/i] and the computer interpolates the frames that appear between them.
+		[Threen] is more suited than [AnimationPlayer] for animations where you don't know the final values in advance. For example, interpolating a dynamically-chosen camera zoom value is best done with a [Threen] node; it would be difficult to do the same thing with an [AnimationPlayer] node.
+		Here is a brief usage example that makes a 2D node move smoothly between two positions:
+		[codeblock]
+		var tween = get_node("Threen")
+		tween.interpolate_property($Node2D, "position",
+		        Vector2(0, 0), Vector2(100, 100), 1,
+		        Threen.TRANS_LINEAR, Threen.EASE_IN_OUT)
+		tween.start()
+		[/codeblock]
+		Many methods require a property name, such as [code]"position"[/code] above. You can find the correct property name by hovering over the property in the Inspector. You can also provide the components of a property directly by using [code]"property:component"[/code] (e.g. [code]position:x[/code]), where it would only apply to that particular component.
+		Many of the methods accept [code]trans_type[/code] and [code]ease_type[/code]. The first accepts an [enum TransitionType] constant, and refers to the way the timing of the animation is handled (see [url=https://easings.net/]easings.net[/url] for some examples). The second accepts an [enum EaseType] constant, and controls where the [code]trans_type[/code] is applied to the interpolation (in the beginning, the end, or both). If you don't know which transition and easing to pick, you can try different [enum TransitionType] constants with [constant EASE_IN_OUT], and use the one that looks best.
+		[url=https://raw.githubusercontent.com/godotengine/godot-docs/3.6/img/tween_cheatsheet.png]Tween easing and transition types cheatsheet[/url]
+		[b]Note:[/b] Threen methods will return [code]false[/code] if the requested operation cannot be completed.
+		[b]Note:[/b] For an alternative method of tweening, that doesn't require using nodes, see [Tween].
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="follow_method">
+			<return type="bool" />
+			<param index="0" name="object" type="Object" />
+			<param index="1" name="method" type="StringName" />
+			<param index="2" name="initial_val" type="Variant" />
+			<param index="3" name="target" type="Object" />
+			<param index="4" name="target_method" type="StringName" />
+			<param index="5" name="duration" type="float" />
+			<param index="6" name="trans_type" type="int" enum="Threen.TransitionType" default="0" />
+			<param index="7" name="ease_type" type="int" enum="Threen.EaseType" default="2" />
+			<param index="8" name="delay" type="float" default="0" />
+			<description>
+				Follows [code]method[/code] of [code]object[/code] and applies the returned value on [code]target_method[/code] of [code]target[/code], beginning from [code]initial_val[/code] for [code]duration[/code] seconds, [code]delay[/code] later. Methods are called with consecutive values.
+				Use [enum TransitionType] for [code]trans_type[/code] and [enum EaseType] for [code]ease_type[/code] parameters. These values control the timing and direction of the interpolation. See the class description for more information.
+			</description>
+		</method>
+		<method name="follow_property">
+			<return type="bool" />
+			<param index="0" name="object" type="Object" />
+			<param index="1" name="property" type="NodePath" />
+			<param index="2" name="initial_val" type="Variant" />
+			<param index="3" name="target" type="Object" />
+			<param index="4" name="target_property" type="NodePath" />
+			<param index="5" name="duration" type="float" />
+			<param index="6" name="trans_type" type="int" enum="Threen.TransitionType" default="0" />
+			<param index="7" name="ease_type" type="int" enum="Threen.EaseType" default="2" />
+			<param index="8" name="delay" type="float" default="0" />
+			<description>
+				Follows [code]property[/code] of [code]object[/code] and applies it on [code]target_property[/code] of [code]target[/code], beginning from [code]initial_val[/code] for [code]duration[/code] seconds, [code]delay[/code] seconds later.
+				Use [enum TransitionType] for [code]trans_type[/code] and [enum EaseType] for [code]ease_type[/code] parameters. These values control the timing and direction of the interpolation. See the class description for more information.
+			</description>
+		</method>
+		<method name="get_runtime" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the total time needed for all tweens to end. If you have two tweens, one lasting 10 seconds and the other 20 seconds, it would return 20 seconds, as by that time all tweens would have finished.
+			</description>
+		</method>
+		<method name="interpolate_callback">
+			<return type="bool" />
+			<param index="0" name="object" type="Object" />
+			<param index="1" name="duration" type="float" />
+			<param index="2" name="callback" type="String" />
+			<param index="3" name="arg1" type="Variant" default="null" />
+			<param index="4" name="arg2" type="Variant" default="null" />
+			<param index="5" name="arg3" type="Variant" default="null" />
+			<param index="6" name="arg4" type="Variant" default="null" />
+			<param index="7" name="arg5" type="Variant" default="null" />
+			<param index="8" name="arg6" type="Variant" default="null" />
+			<param index="9" name="arg7" type="Variant" default="null" />
+			<param index="10" name="arg8" type="Variant" default="null" />
+			<description>
+				Calls [code]callback[/code] of [code]object[/code] after [code]duration[/code]. [code]arg1[/code]-[code]arg5[/code] are arguments to be passed to the callback.
+			</description>
+		</method>
+		<method name="interpolate_deferred_callback">
+			<return type="bool" />
+			<param index="0" name="object" type="Object" />
+			<param index="1" name="duration" type="float" />
+			<param index="2" name="callback" type="String" />
+			<param index="3" name="arg1" type="Variant" default="null" />
+			<param index="4" name="arg2" type="Variant" default="null" />
+			<param index="5" name="arg3" type="Variant" default="null" />
+			<param index="6" name="arg4" type="Variant" default="null" />
+			<param index="7" name="arg5" type="Variant" default="null" />
+			<param index="8" name="arg6" type="Variant" default="null" />
+			<param index="9" name="arg7" type="Variant" default="null" />
+			<param index="10" name="arg8" type="Variant" default="null" />
+			<description>
+				Calls [code]callback[/code] of [code]object[/code] after [code]duration[/code] on the main thread (similar to [method Object.call_deferred]). [code]arg1[/code]-[code]arg5[/code] are arguments to be passed to the callback.
+			</description>
+		</method>
+		<method name="interpolate_method">
+			<return type="bool" />
+			<param index="0" name="object" type="Object" />
+			<param index="1" name="method" type="StringName" />
+			<param index="2" name="initial_val" type="Variant" />
+			<param index="3" name="final_val" type="Variant" />
+			<param index="4" name="duration" type="float" />
+			<param index="5" name="trans_type" type="int" enum="Threen.TransitionType" default="0" />
+			<param index="6" name="ease_type" type="int" enum="Threen.EaseType" default="2" />
+			<param index="7" name="delay" type="float" default="0" />
+			<description>
+				Animates [code]method[/code] of [code]object[/code] from [code]initial_val[/code] to [code]final_val[/code] for [code]duration[/code] seconds, [code]delay[/code] seconds later. Methods are called with consecutive values.
+				Use [enum TransitionType] for [code]trans_type[/code] and [enum EaseType] for [code]ease_type[/code] parameters. These values control the timing and direction of the interpolation. See the class description for more information.
+			</description>
+		</method>
+		<method name="interpolate_property">
+			<return type="bool" />
+			<param index="0" name="object" type="Object" />
+			<param index="1" name="property" type="NodePath" />
+			<param index="2" name="initial_val" type="Variant" />
+			<param index="3" name="final_val" type="Variant" />
+			<param index="4" name="duration" type="float" />
+			<param index="5" name="trans_type" type="int" enum="Threen.TransitionType" default="0" />
+			<param index="6" name="ease_type" type="int" enum="Threen.EaseType" default="2" />
+			<param index="7" name="delay" type="float" default="0" />
+			<description>
+				Animates [code]property[/code] of [code]object[/code] from [code]initial_val[/code] to [code]final_val[/code] for [code]duration[/code] seconds, [code]delay[/code] seconds later. Setting the initial value to [code]null[/code] uses the current value of the property.
+				Use [enum TransitionType] for [code]trans_type[/code] and [enum EaseType] for [code]ease_type[/code] parameters. These values control the timing and direction of the interpolation. See the class description for more information.
+			</description>
+		</method>
+		<method name="is_active" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if any tweens are currently running.
+				[b]Note:[/b] This method doesn't consider tweens that have ended.
+			</description>
+		</method>
+		<method name="remove">
+			<return type="bool" />
+			<param index="0" name="object" type="Object" />
+			<param index="1" name="key" type="StringName" default="&quot;&quot;" />
+			<description>
+				Stops animation and removes a tween, given its object and property/method pair. By default, all tweens are removed, unless [code]key[/code] is specified.
+			</description>
+		</method>
+		<method name="remove_all">
+			<return type="bool" />
+			<description>
+				Stops animation and removes all tweens.
+			</description>
+		</method>
+		<method name="reset">
+			<return type="bool" />
+			<param index="0" name="object" type="Object" />
+			<param index="1" name="key" type="StringName" default="&quot;&quot;" />
+			<description>
+				Resets a tween to its initial value (the one given, not the one before the tween), given its object and property/method pair. By default, all tweens are reset, unless [code]key[/code] is specified.
+			</description>
+		</method>
+		<method name="reset_all">
+			<return type="bool" />
+			<description>
+				Resets all tweens to their initial values (the ones given, not those before the tween).
+			</description>
+		</method>
+		<method name="resume">
+			<return type="bool" />
+			<param index="0" name="object" type="Object" />
+			<param index="1" name="key" type="StringName" default="&quot;&quot;" />
+			<description>
+				Continues animating a stopped tween, given its object and property/method pair. By default, all tweens are resumed, unless [code]key[/code] is specified.
+			</description>
+		</method>
+		<method name="resume_all">
+			<return type="bool" />
+			<description>
+				Continues animating all stopped tweens.
+			</description>
+		</method>
+		<method name="seek">
+			<return type="bool" />
+			<param index="0" name="time" type="float" />
+			<description>
+				Sets the interpolation to the given [code]time[/code] in seconds.
+			</description>
+		</method>
+		<method name="set_active">
+			<return type="void" />
+			<param index="0" name="active" type="bool" />
+			<description>
+				Activates/deactivates the tween. See also [method stop_all] and [method resume_all].
+			</description>
+		</method>
+		<method name="start">
+			<return type="bool" />
+			<description>
+				Starts the tween. You can define animations both before and after this.
+			</description>
+		</method>
+		<method name="stop">
+			<return type="bool" />
+			<param index="0" name="object" type="Object" />
+			<param index="1" name="key" type="StringName" default="&quot;&quot;" />
+			<description>
+				Stops a tween, given its object and property/method pair. By default, all tweens are stopped, unless [code]key[/code] is specified.
+			</description>
+		</method>
+		<method name="stop_all">
+			<return type="bool" />
+			<description>
+				Stops animating all tweens.
+			</description>
+		</method>
+		<method name="targeting_method">
+			<return type="bool" />
+			<param index="0" name="object" type="Object" />
+			<param index="1" name="method" type="StringName" />
+			<param index="2" name="initial" type="Object" />
+			<param index="3" name="initial_method" type="StringName" />
+			<param index="4" name="final_val" type="Variant" />
+			<param index="5" name="duration" type="float" />
+			<param index="6" name="trans_type" type="int" enum="Threen.TransitionType" default="0" />
+			<param index="7" name="ease_type" type="int" enum="Threen.EaseType" default="2" />
+			<param index="8" name="delay" type="float" default="0" />
+			<description>
+				Animates [code]method[/code] of [code]object[/code] from the value returned by [code]initial_method[/code] to [code]final_val[/code] for [code]duration[/code] seconds, [code]delay[/code] seconds later. Methods are animated by calling them with consecutive values.
+				Use [enum TransitionType] for [code]trans_type[/code] and [enum EaseType] for [code]ease_type[/code] parameters. These values control the timing and direction of the interpolation. See the class description for more information.
+			</description>
+		</method>
+		<method name="targeting_property">
+			<return type="bool" />
+			<param index="0" name="object" type="Object" />
+			<param index="1" name="property" type="NodePath" />
+			<param index="2" name="initial" type="Object" />
+			<param index="3" name="initial_val" type="NodePath" />
+			<param index="4" name="final_val" type="Variant" />
+			<param index="5" name="duration" type="float" />
+			<param index="6" name="trans_type" type="int" enum="Threen.TransitionType" default="0" />
+			<param index="7" name="ease_type" type="int" enum="Threen.EaseType" default="2" />
+			<param index="8" name="delay" type="float" default="0" />
+			<description>
+				Animates [code]property[/code] of [code]object[/code] from the current value of the [code]initial_val[/code] property of [code]initial[/code] to [code]final_val[/code] for [code]duration[/code] seconds, [code]delay[/code] seconds later.
+				Use [enum TransitionType] for [code]trans_type[/code] and [enum EaseType] for [code]ease_type[/code] parameters. These values control the timing and direction of the interpolation. See the class description for more information.
+			</description>
+		</method>
+		<method name="tell" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the current time of the tween.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="playback_process_mode" type="int" setter="set_tween_process_mode" getter="get_tween_process_mode" enum="Threen.TweenProcessMode" default="1">
+			The tween's animation process thread. See [enum TweenProcessMode].
+		</member>
+		<member name="playback_speed" type="float" setter="set_speed_scale" getter="get_speed_scale" default="1.0">
+			The tween's speed multiplier. For example, set it to [code]1.0[/code] for normal speed, [code]2.0[/code] for two times normal speed, or [code]0.5[/code] for half of the normal speed. A value of [code]0[/code] pauses the animation, but see also [method set_active] or [method stop_all] for this.
+		</member>
+		<member name="repeat" type="bool" setter="set_repeat" getter="is_repeat" default="false">
+			If [code]true[/code], the tween loops.
+		</member>
+	</members>
+	<signals>
+		<signal name="tween_all_completed">
+			<description>
+				Emitted when all processes in a tween end.
+			</description>
+		</signal>
+		<signal name="tween_completed">
+			<param index="0" name="object" type="Object" />
+			<param index="1" name="key" type="NodePath" />
+			<description>
+				Emitted when a tween ends.
+			</description>
+		</signal>
+		<signal name="tween_started">
+			<param index="0" name="object" type="Object" />
+			<param index="1" name="key" type="NodePath" />
+			<description>
+				Emitted when a tween starts.
+			</description>
+		</signal>
+		<signal name="tween_step">
+			<param index="0" name="object" type="Object" />
+			<param index="1" name="key" type="NodePath" />
+			<param index="2" name="elapsed" type="float" />
+			<param index="3" name="value" type="Object" />
+			<description>
+				Emitted at each step of the animation.
+			</description>
+		</signal>
+	</signals>
+	<constants>
+		<constant name="TWEEN_PROCESS_PHYSICS" value="0" enum="TweenProcessMode">
+			The tween updates with the [code]_physics_process[/code] callback.
+		</constant>
+		<constant name="TWEEN_PROCESS_IDLE" value="1" enum="TweenProcessMode">
+			The tween updates with the [code]_process[/code] callback.
+		</constant>
+		<constant name="TRANS_LINEAR" value="0" enum="TransitionType">
+			The animation is interpolated linearly.
+		</constant>
+		<constant name="TRANS_SINE" value="1" enum="TransitionType">
+			The animation is interpolated using a sine function.
+		</constant>
+		<constant name="TRANS_QUINT" value="2" enum="TransitionType">
+			The animation is interpolated with a quintic (to the power of 5) function.
+		</constant>
+		<constant name="TRANS_QUART" value="3" enum="TransitionType">
+			The animation is interpolated with a quartic (to the power of 4) function.
+		</constant>
+		<constant name="TRANS_QUAD" value="4" enum="TransitionType">
+			The animation is interpolated with a quadratic (to the power of 2) function.
+		</constant>
+		<constant name="TRANS_EXPO" value="5" enum="TransitionType">
+			The animation is interpolated with an exponential (to the power of x) function.
+		</constant>
+		<constant name="TRANS_ELASTIC" value="6" enum="TransitionType">
+			The animation is interpolated with elasticity, wiggling around the edges.
+		</constant>
+		<constant name="TRANS_CUBIC" value="7" enum="TransitionType">
+			The animation is interpolated with a cubic (to the power of 3) function.
+		</constant>
+		<constant name="TRANS_CIRC" value="8" enum="TransitionType">
+			The animation is interpolated with a function using square roots.
+		</constant>
+		<constant name="TRANS_BOUNCE" value="9" enum="TransitionType">
+			The animation is interpolated by bouncing at the end.
+		</constant>
+		<constant name="TRANS_BACK" value="10" enum="TransitionType">
+			The animation is interpolated backing out at ends.
+		</constant>
+		<constant name="EASE_IN" value="0" enum="EaseType">
+			The interpolation starts slowly and speeds up towards the end.
+		</constant>
+		<constant name="EASE_OUT" value="1" enum="EaseType">
+			The interpolation starts quickly and slows down towards the end.
+		</constant>
+		<constant name="EASE_IN_OUT" value="2" enum="EaseType">
+			A combination of [constant EASE_IN] and [constant EASE_OUT]. The interpolation is slowest at both ends.
+		</constant>
+		<constant name="EASE_OUT_IN" value="3" enum="EaseType">
+			A combination of [constant EASE_IN] and [constant EASE_OUT]. The interpolation is fastest at both ends.
+		</constant>
+	</constants>
+</class>


### PR DESCRIPTION
Class reference copied from the 3.6 docs.

Depends on:
- https://github.com/godotengine/godot/pull/91518
- https://github.com/godotengine/godot-cpp/pull/1374

Which will be merged for 4.3, so merging this will make future builds of the extension 4.3+.

![image](https://github.com/akien-mga/threen/assets/4701338/b1d7b1fd-4d6e-4f4e-8aeb-60b65247bca6)
![image](https://github.com/akien-mga/threen/assets/4701338/fcb19cd8-e2d7-493a-ad8e-83e8efc620e2)